### PR TITLE
Bump dependencies (01/09)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6237,9 +6237,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3370,9 +3370,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.1.tgz",
-      "integrity": "sha512-gceRaITVZ+cJH9sNHqx5tFwbzlLCVxtVZcusME8JYQ8Edy5mpGDOqD8QBCdMhpyo9a+JXddnujQ4rpY2Ff9SJA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
+      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
       "dev": true
     },
     "iconv-lite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1424,9 +1424,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.29.2.tgz",
-      "integrity": "sha512-eUxibZD92k+rY0oZJFZooGqdVpGkDrrHlUhj9UAWrtoyXCGmNOWC1Kcr2KPrZoHRSlWwHOcRnkn2nGT+aHY2KA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.30.0.tgz",
+      "integrity": "sha512-16ePj2GkwjomvE0HLL5ny+d+sudOwvZNYW8vjpMh3cyWdFxoMI8KSQiolVxeHBULbU1C5mVxLK5nL9NtnnpIew==",
       "dev": true
     },
     "abab": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6222,9 +6222,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.0.0.tgz",
-      "integrity": "sha512-BoEUnckjP9oiudy3KxlGdudtBAdJQ74Wp7dYwVPkUzBn+cVHOsBXh2zD2jLyqgbuJ1KMNriczZCI7lTBA94dFg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.1.0.tgz",
+      "integrity": "sha512-2wHUmKDy5wNLmebekbHx/zE9ElYAKOmz34psTLG7OwyEJHaIUr6jnaCd55EvgrawAvliwbwgbyH1LkxIfWFyNg==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,9 +1234,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
-      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
+      "version": "16.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
+      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@guardian/prettier": "^0.6.0",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.7.6",
-    "@vercel/ncc": "^0.29.1",
+		"@vercel/ncc": "^0.30.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",
     "husky": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/prettier": "^0.6.0",
     "@types/jest": "^27.0.1",
-    "@types/node": "^16.6.1",
+    "@types/node": "^16.7.6",
     "@vercel/ncc": "^0.29.1",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",
-    "type-fest": "^2.0.0",
+    "type-fest": "^2.1.0",
     "typescript": "^4.4.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",
     "type-fest": "^2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.2"
   },
   "engines": {
     "yarn": "please-use-npm"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@vercel/ncc": "^0.29.1",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",
-    "husky": "^7.0.1",
+    "husky": "^7.0.2",
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",


### PR DESCRIPTION
* bump husky from 7.0.1 to 7.0.2
* bump typescript from 4.3.5 to 4.4.2
* bump type-fest from 2.0.0 to 2.1.0
* bump @types/node from 16.6.2 to 16.7.6
* bump @vercel/ncc from 0.29.2 to 0.30.0