### PR TITLE
chore(deps): Bump dependencies (13/10)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7636,22 +7636,13 @@ var external_fs_ = __nccwpck_require__(5747);
 // EXTERNAL MODULE: ./node_modules/@actions/exec/lib/exec.js
 var exec = __nccwpck_require__(1514);
 ;// CONCATENATED MODULE: ./src/actions/components.ts
-var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 
 
 
-const analyseComponents = () => __awaiter(void 0, void 0, void 0, function* () {
+const analyseComponents = async () => {
     writeConfigFile();
-    yield scan();
-});
+    await scan();
+};
 // TODO: Make parts of config configurable
 const config = `
 module.exports = {
@@ -7677,10 +7668,10 @@ const writeConfigFile = () => {
     (0,core.info)('Writing config file');
     (0,external_fs_.writeFileSync)('.source/scan.config.js', config);
 };
-const scan = () => __awaiter(void 0, void 0, void 0, function* () {
+const scan = async () => {
     (0,core.info)('Running react-scanner');
-    yield (0,exec.exec)('npx react-scanner -c .source/scan.config.js');
-});
+    await (0,exec.exec)('npx react-scanner -c .source/scan.config.js');
+};
 
 ;// CONCATENATED MODULE: ./src/actions/packages.ts
 
@@ -7693,7 +7684,10 @@ const analysePackages = () => {
     const allPackages = Object.keys(packageJson.dependencies).filter((pkg) => pkg.startsWith('@guardian/src-'));
     // TODO: Figure out what to do about `@guardian/src-foundations`
     const unusedPackages = allPackages.filter((pkg) => !usedPackages.includes(pkg) && pkg !== '@guardian/src-foundations');
-    const packageVersions = allPackages.reduce((versions, pkg) => (Object.assign(Object.assign({}, versions), { [pkg]: packageJson.dependencies[pkg] })), {});
+    const packageVersions = allPackages.reduce((versions, pkg) => ({
+        ...versions,
+        [pkg]: packageJson.dependencies[pkg],
+    }), {});
     (0,external_fs_.writeFileSync)('.source/output/packages.json', JSON.stringify({
         usedPackages,
         unusedPackages,
@@ -7702,43 +7696,31 @@ const analysePackages = () => {
 };
 
 ;// CONCATENATED MODULE: ./src/lib/pkg.ts
-var _a;
-const pkg_name = (_a = __nccwpck_require__(306)/* .name */ .u2) !== null && _a !== void 0 ? _a : "Couldn't find package name?";
+const pkg_name = __nccwpck_require__(306)/* .name */ .u2 ??
+    "Couldn't find package name?";
 
 ;// CONCATENATED MODULE: ./src/index.ts
-var src_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 
 
 
 
 
-function run() {
-    var _a;
-    return src_awaiter(this, void 0, void 0, function* () {
-        try {
-            (0,core.info)(`Running ${pkg_name}`);
-            (0,core.debug)(`Event name: ${github.context.eventName}`);
-            (0,core.debug)(`Action type: ${(_a = github.context.payload.action) !== null && _a !== void 0 ? _a : 'Unknown'}`);
-            yield analyseComponents();
-            analysePackages();
+async function run() {
+    try {
+        (0,core.info)(`Running ${pkg_name}`);
+        (0,core.debug)(`Event name: ${github.context.eventName}`);
+        (0,core.debug)(`Action type: ${github.context.payload.action ?? 'Unknown'}`);
+        await analyseComponents();
+        analysePackages();
+    }
+    catch (error) {
+        if (error instanceof Error) {
+            (0,core.setFailed)(error.message);
         }
-        catch (error) {
-            if (error instanceof Error) {
-                (0,core.setFailed)(error.message);
-            }
-            else {
-                throw error;
-            }
+        else {
+            throw error;
         }
-    });
+    }
 }
 void run();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1424,9 +1424,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.30.0.tgz",
-      "integrity": "sha512-16ePj2GkwjomvE0HLL5ny+d+sudOwvZNYW8vjpMh3cyWdFxoMI8KSQiolVxeHBULbU1C5mVxLK5nL9NtnnpIew==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.31.0.tgz",
+      "integrity": "sha512-vpioWEFk00Sk5CgJj39LFAjqXcM0PLcaSqaEDeZZUKfHEKYmHL5tOns7Xd21/o4SKzRi+XE0qhEv9wWwkfmNaA==",
       "dev": true
     },
     "abab": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2529,15 +2529,15 @@
       }
     },
     "eslint-import-resolver-typescript": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz",
-      "integrity": "sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.5.0.tgz",
+      "integrity": "sha512-qZ6e5CFr+I7K4VVhQu3M/9xGv9/YmwsEXrsm3nimw8vWaVHRDrQRp26BgCypTxBp3vUp4o5aVEJRiy0F2DFddQ==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1",
-        "glob": "^7.1.6",
+        "debug": "^4.3.1",
+        "glob": "^7.1.7",
         "is-glob": "^4.0.1",
-        "resolve": "^1.17.0",
+        "resolve": "^1.20.0",
         "tsconfig-paths": "^3.9.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -625,9 +625,9 @@
       }
     },
     "@guardian/prettier": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@guardian/prettier/-/prettier-0.6.0.tgz",
-      "integrity": "sha512-RN8GBRth5BXHoWymCZIYDbmZM8DkUbgecf+wyv+9hdXA/ad4Ob4qP9u/ARU689qMo+JSC1z3FRKelvkkjtYzJw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@guardian/prettier/-/prettier-0.7.0.tgz",
+      "integrity": "sha512-1FPQ3QDbb5lPcOKJJy0aU6lU9h9CSe91FI4J9ZZ6Qc9Ewb2XS5VL1eX2df2YJOGZ+nXo90Q/YG7+LUUYtcQKKw==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6222,9 +6222,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.1.0.tgz",
-      "integrity": "sha512-2wHUmKDy5wNLmebekbHx/zE9ElYAKOmz34psTLG7OwyEJHaIUr6jnaCd55EvgrawAvliwbwgbyH1LkxIfWFyNg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.3.2.tgz",
+      "integrity": "sha512-cfvZ1nOC/VqAt8bVOIlFz8x+HdDASpiFYrSi0U0nzcAFlOnzzQ/gsPg2PP1uqjreO7sQCtraYJHMduXSewQsSA==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,9 +1234,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
-      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.6.0",
-    "@guardian/prettier": "^0.6.0",
+    "@guardian/prettier": "^0.7.0",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.1",
 		"@vercel/ncc": "^0.30.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/prettier": "^0.6.0",
     "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
+    "@types/node": "^16.9.1",
 		"@vercel/ncc": "^0.30.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^16.9.1",
 		"@vercel/ncc": "^0.30.0",
     "eslint": "^7.32.0",
-    "eslint-import-resolver-typescript": "^2.4.0",
+    "eslint-import-resolver-typescript": "^2.5.0",
     "husky": "^7.0.2",
     "jest": "^26.6.3",
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@guardian/prettier": "^0.7.0",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.1",
-		"@vercel/ncc": "^0.30.0",
+    "@vercel/ncc": "^0.31.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "husky": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-jest": "^26.5.6",
-    "type-fest": "^2.1.0",
+    "type-fest": "^2.3.2",
     "typescript": "^4.4.2"
   },
   "engines": {


### PR DESCRIPTION
* bump type-fest from 2.1.0 to 2.3.2
* bump @types/node from 16.7.10 to 16.9.1
* bump eslint-import-resolver-typescript from 2.4.0 to 2.5.0
* bump @guardian/prettier from 0.6.0 to 0.7.0
* bump @vercel/ncc from 0.30.0 to 0.31.0